### PR TITLE
Update configured-workflow-fails-running.md

### DIFF
--- a/SharePoint/SharePointOnline/workflows/configured-workflow-fails-running.md
+++ b/SharePoint/SharePointOnline/workflows/configured-workflow-fails-running.md
@@ -45,6 +45,6 @@ To work around this issue, configure your workflow to send email messages withou
 
 ## More information
 
-This issue occurs when you exceed the Exchange Online message limits. For more information, see [Exchange Online Limits](https://docs.microsoft.com/office365/servicedescriptions/exchange-online-service-description/exchange-online-limits#recipientlimits).
+This issue occurs when you exceed the Exchange Online message limits configured for SharePoint Online outgoing emails. 
 
 Still need help? Go to [Microsoft Community](https://answers.microsoft.com).


### PR DESCRIPTION
The article we're linking to states the recipient limit is 500, not 200 as this article is asserting.  After investigating with Exchange Online, it was determined the 200 recipient limit is only for SharePoint outgoing emails, so removing reference and link to https://docs.microsoft.com/en-us/office365/servicedescriptions/exchange-online-service-description/exchange-online-limits.