### PR TITLE
Updating PowerShell at line 85

### DIFF
--- a/SkypeforBusiness/SkypeHybrid/hybrid-exchange-integration/allowadalfornonlyncIndependentofLync-setting.md
+++ b/SkypeforBusiness/SkypeHybrid/hybrid-exchange-integration/allowadalfornonlyncIndependentofLync-setting.md
@@ -82,7 +82,8 @@ Then, apply the **AllowAdalForNonLyncIndependentOfLync** registry key setting: 
 To enable the in-band setting on the Lync server, run the following cmdlet:   
 
 ```powershell
-$a = New-CsClientPolicyEntry -name AllowAdalForNonLyncIndependentOfLync -value "True" Set-CsClientPolicy -Identity Global -PolicyEntry @{Add=$a} 
+$a = New-CsClientPolicyEntry -name AllowAdalForNonLyncIndependentOfLync -value "True" 
+Set-CsClientPolicy -Identity Global -PolicyEntry @{Add=$a} 
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
Both commands were on the same line which would result in an error when run by the end user.
Split commands by a new line.