### PR TITLE
Update click-to-run-office-on-terminal-server.md

### DIFF
--- a/Office/Client/error-messages/click-to-run-office-on-terminal-server.md
+++ b/Office/Client/error-messages/click-to-run-office-on-terminal-server.md
@@ -39,7 +39,7 @@ In Microsoft Office 2016:
 
 ## Cause
 
-This issue occurs because you can't install Click-to-Run versions of Office programs or suites on a server that's running Remote Desktop Services (formerly known as Terminal Services).
+This issue occurs because Click-to-Run versions of Office programs or suites running on a server with Remote Desktop Services (RDS), must have [Shared Computer Activation](https://docs.microsoft.com/en-us/deployoffice/overview-of-shared-computer-activation-for-office-365-proplus) enabled. Remote Desktop Services are formerly known as Terminal Services. Shared Computer Activation is only available for Microsoft 365 Apps. Other releases are not supported.
 
 ## Workaround
 


### PR DESCRIPTION
Updated wording under "cause" based on customer feedback thrown off by a hard statement that C2R Office on RDS is not supported. Clarified that Office is supported when running with SCA.