### PR TITLE
Proposing change in title

### DIFF
--- a/Exchange/ExchangeOnline/connectors/office-365-notice.md
+++ b/Exchange/ExchangeOnline/connectors/office-365-notice.md
@@ -1,5 +1,5 @@
 ---
-title: Important notice for Office 365 email customers who have configured connectors
+title: Configure a certificate-based connector to relay email messages through Office 365
 description: Describes scenarios that requires you to take action before February 1, 2017 to prevent interruptions to mail flow.
 author: simonxjx
 audience: ITPro
@@ -14,12 +14,6 @@ search.appverid:
 appliesto:
 - Exchange Online
 ---
-
-# Important notice for Office 365 email customers who have configured connectors
-
-## Notice
-
-If you are an Exchange Online or Exchange Online Protection (EOP) customer, and you have configured connectors, this article contains important information that might affect your organization. To make sure that your mail flow isn’t interrupted, we strongly recommend that you read this article and take any necessary action before the July 5, 2017, deadline.
 
 ## Introduction 
 

--- a/Exchange/ExchangeOnline/connectors/office-365-notice.md
+++ b/Exchange/ExchangeOnline/connectors/office-365-notice.md
@@ -15,6 +15,8 @@ appliesto:
 - Exchange Online
 ---
 
+# Configure a certificate-based connector to relay email messages through Office 365
+
 ## Introduction 
 
 If your organization has a hybrid deployment (on-premises plus Microsoft Office 365), you frequently have to relay email messages to the Internet through Office 365. That is, messages that you send from your on-premises environment (mailboxes, applications, scanners, fax machines, and so on) to Internet recipients are first routed to Office 365, and then sent out. 


### PR DESCRIPTION
Many customers use this Article to relay email from on-prem Application or servers to internet through Office 365. However the title of the Article is somewhat misleading. The change happened in early 2017. I propose a title that is more generic to this requirement and something that customers can find easily. Also removing the "Important Notice Part" which does not seem relevant anymore.