### PR TITLE
Fix ConvertToLetter VBA function

### DIFF
--- a/Office/Client/excel/convert-excel-column-numbers.md
+++ b/Office/Client/excel/convert-excel-column-numbers.md
@@ -84,7 +84,7 @@ Function ConvertToLetter(iCol As Long) As String
    Do While iCol > 0
       a = Int((iCol - 1) / 26)
       b = (iCol - 1) Mod 26
-      ConvertToLetter2 = Chr(b + 65) & ConvertToLetter
+      ConvertToLetter = Chr(b + 65) & ConvertToLetter
       iCol = a
    Loop
 End Function


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/MicrosoftDocs/OfficeDocs-Support/issues) open

### Description
I replaced **ConvertToLetter2** by **ConvertToLetter** in **ConvertToLetter** VBA function to solve variable not defined compile error.