### PR TITLE
Typo "**SMTP:～@contoso.com**"→"**SMTP:～\@contoso.com**"

### DIFF
--- a/Exchange/ExchangeServer/client-connectivity/accessing-shared-mailboxes-fails.md
+++ b/Exchange/ExchangeServer/client-connectivity/accessing-shared-mailboxes-fails.md
@@ -63,7 +63,7 @@ Add a primary SMTP address to the proxyAddresses attribute for the service accou
 7. Find the **proxyAddresses** attribute, and then select **Edit**.
 8. In the **Value to add** text box, add the following text to set a primary SMTP address, and then select the **Add** button:
 
-   **SMTP:serviceaccount01@contoso.com**
+   **SMTP:serviceaccount01\@contoso.com**
 
 9. Select **OK** two times, and then close Active Directory Users and Computers.
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/exchange/troubleshoot/client-connectivity/accessing-shared-mailboxes-fails