### PR TITLE
Update office-web-apps-and-vmware.md

### DIFF
--- a/Office/OfficeExperts/administration/office-web-apps-and-vmware.md
+++ b/Office/OfficeExperts/administration/office-web-apps-and-vmware.md
@@ -15,11 +15,11 @@ appliesto:
 - Office Online Server
 ---
 
-# Microsoft Offices Online 2013 and VMWare
+# Microsoft Office Web Apps 2013 and VMWare
 
 This article was written by [Tom Schauer](https://social.technet.microsoft.com/profile/Tom+Schauer+-+MSFT), Technical Specialist.
 
-Several issues occur when installing Microsoft Offices Online 2013 or Office Online Server on a nonsystem Drive by using VMWare. The problem lies in setting the Microsoft Offices Online CacheLocation or RenderingCacheLocation to a nonsystem drive location with the HotAdd/HotPlug capability in VMWare.
+Several issues occur when installing Microsoft Office Web Apps 2013 or Office Online Server on a nonsystem Drive by using VMWare. The problem lies in setting the Microsoft Office Web Apps CacheLocation or RenderingCacheLocation to a nonsystem drive location with the HotAdd/HotPlug capability in VMWare.
 
 There are numerous possible symptoms for this issue, most visibly when viewing/editing documents. For example, you might see the following error in the SharePoint Unified Logging Service (ULS) logs.
 
@@ -39,7 +39,7 @@ Here is an example of what you are seeing in the ULS logs:
 
 ## Resolution
 
-The most reliable resolution is to uninstall Microsoft Offices Online or Office Online Server, then reinstall (on the drive C), apply updates and rebuild the farm.
+The most reliable resolution is to uninstall Microsoft Office Web Apps or Office Online Server, then reinstall (on the drive C), apply updates and rebuild the farm.
 
 You can also use the method that is provided in the following article to work around the issue:
 


### PR DESCRIPTION
Product names referenced in this article is incorrect. There is no such thing as Offices Online 2013.

This documentation applies to Office Web Apps 2013, an On-Premise server product used to view and Edit Office files through the browser as documented here:

- Office Web Apps Server overview: https://docs.microsoft.com/en-us/webappsserver/office-web-apps-server-overview

The following articles need to be corrected to reflect the correct product names (Office Web Apps 2013 vs. Offices Online 2013):

- https://docs.microsoft.com/en-us/office/troubleshoot/administration/rebuild-an-office-web-apps-2013-farm-easily
- https://docs.microsoft.com/en-us/office/troubleshoot/administration/office-web-apps-and-vmware

https://github.com/MicrosoftDocs/OfficeDocs-Support/issues/881