### PR TITLE
Update rebuild-an-office-web-apps-2013-farm-easily.md

### DIFF
--- a/Office/OfficeExperts/administration/rebuild-an-office-web-apps-2013-farm-easily.md
+++ b/Office/OfficeExperts/administration/rebuild-an-office-web-apps-2013-farm-easily.md
@@ -1,5 +1,5 @@
 ﻿---
-title: Rebuild an Microsoft Offices Online 2013 farm easily
+title: Rebuild an Microsoft Office Web Apps 2013 server farm easily
 author: AmandaAZ
 ms.author: brbering
 manager: dcscontentpm
@@ -13,18 +13,18 @@ ms.custom: CSSTroubleshoot
 appliesto:
 - Office Web Apps 2013
 ---
-# Rebuild an Microsoft Offices Online 2013 farm easily
+# Rebuild an Microsoft Office Web Apps 2013 server farm easily
 
 This article was written by [Tom Schauer](https://social.technet.microsoft.com/profile/Tom+Schauer+-+MSFT), Technical Specialist.
 
-You can rebuild Microsoft Microsoft Offices Online 2013 farm with a few easy steps. To do this, follow these steps:
+You can rebuild Microsoft Microsoft Office Web Apps 2013 server farm with a few easy steps. To do this, follow these steps:
 
 > [!NOTE]
 >- Because there is a minimal configuration from an Office Web Apps perspective and zero data loss, there is little risk to rebuild an Office Web Apps farm.
 >- These steps can be used for fixing technical issues with Office Web Apps.
 
-1. Take the Microsoft Offices Online farm offline if there is a load balancer.
-1. Collect the current farm information through PowerShell by using the following command on an Microsoft Offices Online (WAC) Server(s):
+1. Take the Microsoft Office Web Apps 2013 server farm offline if there is a load balancer.
+1. Collect the current farm information through PowerShell by using the following command on an Microsoft Office Web Apps 2013 (WAC) Server(s):
 
    **Get-OfficeWebAppsFarm > c:\MyWACfarm.txt**
 
@@ -37,7 +37,7 @@ You can rebuild Microsoft Microsoft Offices Online 2013 farm with a few easy ste
 
    To find which server is the Parent and which servers are the Child, review the farm output from step 2 and look toward at the bottom for "Machines" listed. The first server is your Parent server and the rest are Child servers. Run the following command on the Child servers first, and as soon as it is completed, run the command on the Parent server. This will delete the farm.
 
-1. Reboot the Office Online Servers.
+1. Reboot the Office Web Apps Servers.
 1. Re-create the farm through PowerShell on WAC servers by using the parameter values from the command that we ran in step 2.
 
    **New-OfficeWebAppsFarm -InternalURL "http://WACServer.corp.contoso.com" -AllowHttp -EditingEnabled -OpenFromURLEnabled**
@@ -54,9 +54,9 @@ You can rebuild Microsoft Microsoft Offices Online 2013 farm with a few easy ste
 
    **New-SPWOPIBinding –ServerName "WACServer.corp.contoso.com" -AllowHttp**
 
-To verify that your Microsoft Offices Online was configured correctly, go to **https://servername/hosting/discovery** in a web browser.
+To verify that your Microsoft Office Web Apps 2013 server farm was configured correctly, go to **https://servername/hosting/discovery** in a web browser.
 
-If Office Online Server is working as expected, you should see a **Web Application Open Platform Interface Protocol (WOPI)-discovery** XML file in your web browser.
+If Office Web Apps 2013 server is working as expected, you should see a **Web Application Open Platform Interface Protocol (WOPI)-discovery** XML file in your web browser.
 
 For example:
 ```
@@ -68,4 +68,4 @@ For example:
 > [!NOTE]
 > You need to replace **WACServer.corp.contoso.com** in previous steps with the correct information from your farm.
 
-For more information about how to configure Microsoft Offices Online, see [Configure Microsoft Offices Online for SharePoint 2013](https://technet.microsoft.com/library/ff431687).
+For more information about how to configure Microsoft Office Web Apps 2013, see [Configure Microsoft Office Web Apps 2013 for SharePoint 2013](https://technet.microsoft.com/library/ff431687).


### PR DESCRIPTION
Product names referenced in this article is incorrect. There is no such thing as Offices Online 2013. This documentation applies to Office Web Apps 2013, an On-Premise server product used to view and Edit Office files through the browser as documented here:

- Office Web Apps Server overview: https://docs.microsoft.com/en-us/webappsserver/office-web-apps-server-overview

The following articles need to be corrected to reflect the correct product names (Office Web Apps 2013 vs. Offices Online 2013):

- https://docs.microsoft.com/en-us/office/troubleshoot/administration/rebuild-an-office-web-apps-2013-farm-easily
- https://docs.microsoft.com/en-us/office/troubleshoot/administration/office-web-apps-and-vmware

See: https://github.com/MicrosoftDocs/OfficeDocs-Support/issues/881