### PR TITLE
Update test-viewing-documents-by-using-office-online-server-viewer.md

### DIFF
--- a/Office/OfficeExperts/administration/test-viewing-documents-by-using-office-online-server-viewer.md
+++ b/Office/OfficeExperts/administration/test-viewing-documents-by-using-office-online-server-viewer.md
@@ -18,7 +18,7 @@ appliesto:
 
 This article was written by [Tom Schauer](https://social.technet.microsoft.com/profile/Tom+Schauer+-+MSFT), Technical Specialist.
 
-Microsoft Office Online Server or Office Online Server has a built-in Office file viewer for testing viewing Office files in a browser, independent of any integration such as SharePoint Server, Skype for Business Server, or Exchange Server. This article introduces how to test viewing Office documents by using Microsoft Offices Online or Office Online Server viewer, as follows:
+Microsoft Office Web Apps 2013 Server or Office Online Server has a built-in Office file viewer for testing viewing Office files in a browser, independent of any integration such as SharePoint Server, Skype for Business Server, or Exchange Server. This article introduces how to test viewing Office documents by using Microsoft Offices Online or Office Online Server viewer, as follows:
 
 1. By default, the **OpenFromURLEnabled** parameter is set to **False** in a new Microsoft Offices Online farm. To set it to **True**, run the following command in PowerShell on a Microsoft Offices Online (WAC) server:
 


### PR DESCRIPTION
Office Online Server is repeated twice on line 21 in the opening sentence. This should refer to Office Online Server and it's predecessor, Office Web Apps 2013 Server.