### PR TITLE
Updates required for proper contextual searching

### DIFF
--- a/Teams/teams-sign-in/someone-has-already-setup-teams.md
+++ b/Teams/teams-sign-in/someone-has-already-setup-teams.md
@@ -1,5 +1,5 @@
 ---
-title: Someone has already setup Teams for your organization error in Microsoft Teams
+title: Someone has already set up Teams for your organization error in Microsoft Teams
 description: Resolves an issue in which Microsoft Teams returns an error message when you try to set up your account. 
 author: TobyTu
 ms.author: billkau
@@ -18,11 +18,11 @@ search.appverid:
 - MET150
 ---
 
-# "Someone has already setup Teams for your organization" error in Microsoft Teams
+# "Someone has already set up Teams for your organization" error in Microsoft Teams
 
 ## Symptoms
 
-When you try to set up a Microsoft Teams account, you receive a "Someone has already setup Teams for your organization" error message.
+When you try to set up a Microsoft Teams account, you receive a "Someone has already set up Teams for your organization" error message.
 
 ## Resolution
 


### PR DESCRIPTION
When someone receives the error, it's not 'someone has already setup Teams' it's, 'someone has already set up Teams', 
  "license_error_msa_user_in_a_claimed_domain_title": "Someone has already set up Teams for your organisation",

Correcting to ensure folks searching for this can have this document pop up first vs. Answers.microsoft.com.

@marclauinger FYI