### PR TITLE
msExchResourceCapacity and msExchResourceDisplay

### DIFF
--- a/Exchange/ExchangeHybrid/calendars/only-can-see-availability-info-of-resource-when-scheduling-meeting.md
+++ b/Exchange/ExchangeHybrid/calendars/only-can-see-availability-info-of-resource-when-scheduling-meeting.md
@@ -52,7 +52,8 @@ To do this, follow these steps:
    3. Examine the output, and note the values that are returned for the `ResourceCapacity` and `ResourceCustom` properties.
 2. Use the values that you obtained in step 1 to update the `msExchResourceCapacity` and `msExchResourceDisplay` attributes of the objects in the on-premises Active Directory.
 
-Note: You may run into warning while you access such room or equipment mailboxes if they are attempted to be accessed using EAC or Exchange Management Shell in OnPremise server. In case this needs to be modified some properties at the OnPremise server, clear these attributes and perform the intended task using Exchange Management Shell or EAC. Upon completion you can update `msExchResourceCapacity` and  `msExchResourceDisplay` back to original values.
+> [!NOTE]
+> You may receive warnings when you access such room or equipment mailboxes if they're attempted to be accessed by using EAC or Exchange Management Shell in the on-premises Exchange server. If you need to modify some properties on the on-premises Exchange server, clear these attributes, and perform the intended task by using Exchange Management Shell or EAC. Upon completion you can update `msExchResourceCapacity` and `msExchResourceDisplay` back to the original values.
 
 ## More information
 

--- a/Exchange/ExchangeHybrid/calendars/only-can-see-availability-info-of-resource-when-scheduling-meeting.md
+++ b/Exchange/ExchangeHybrid/calendars/only-can-see-availability-info-of-resource-when-scheduling-meeting.md
@@ -52,6 +52,8 @@ To do this, follow these steps:
    3. Examine the output, and note the values that are returned for the `ResourceCapacity` and `ResourceCustom` properties.
 2. Use the values that you obtained in step 1 to update the `msExchResourceCapacity` and `msExchResourceDisplay` attributes of the objects in the on-premises Active Directory.
 
+Note: You may run into warning while you access such room or equipment mailboxes if they are attempted to be accessed using EAC or Exchange Management Shell in OnPremise server. In case this needs to be modified some properties at the OnPremise server, clear these attributes and perform the intended task using Exchange Management Shell or EAC. Upon completion you can update `msExchResourceCapacity` and  `msExchResourceDisplay` back to original values.
+
 ## More information
 
 Still need help? Go to [Microsoft Community](https://answers.microsoft.com/) or the [Microsoft Q&A](/answers/products/?WT.mc_id=msdnredirect-web-msdn).


### PR DESCRIPTION
Adding msExchResourceCapacity and msExchResourceDisplay attribute value causes warning to be displayed while attempting to view the properties of such resource mailbox in OnPremise Servers.

Error message reported is:
WARNING: The object contoso.lab/Hybrid Mailboxes/testroom has been corrupted or isn't compatible with Microsoft
support requirements, and it's in an inconsistent state. The following validation errors happened:
WARNING: The type of the resource mailbox can't be blank. It should be either Room or Equipment.

From my understanding this error happens due to validation of object when we attempt to display the user property and it shows failure. Removing these properties fixes the error.

Would be better to have documented that they should not be managing the Room or Equipment mailboxes from OnPremise instead should be doing it from Exchange Online as a disclaimer. 

Note: You may run into warning while you access such room or equipment mailboxes if they are attempted to be accessed using EAC or Exchange Management Shell in OnPremise server. In case this needs to be modified some properties at the OnPremise server, clear these attributes and perform the intended task using Exchange Management Shell or EAC. Upon completion you can update `msExchResourceCapacity` and  `msExchResourceDisplay` back to original values.