### PR TITLE
Update rest-api-is-not-yet-supported-for-this-mailbox-error.md

### DIFF
--- a/Exchange/ExchangeOnline/user-and-shared-mailboxes/rest-api-is-not-yet-supported-for-this-mailbox-error.md
+++ b/Exchange/ExchangeOnline/user-and-shared-mailboxes/rest-api-is-not-yet-supported-for-this-mailbox-error.md
@@ -11,7 +11,7 @@ localization_priority: Normal
 ms.custom: 
 - Exchange Online
 - CSSTroubleshoot
-ms.reviewer: evsung, rachaudh
+ms.reviewer: evsung, rachaudh, brianja, jasonjoh
 appliesto:
 - Power Automate  
 search.appverid: MET150


### PR DESCRIPTION
These changes had been made to the article version in Portico in Sept 2020 but the migration was done using a previous version of the article that had been converted to .md using the conversion tool. The verbiage in this article was wrong and caused problems in Sept and the same problem has re-surfaced now because of the inaccuracy in the content. Hence fixing this version.