### PR TITLE
Remove references to Configuration Manager

### DIFF
--- a/Teams/direct-routing/sip-options-tls-certificate-issues.md
+++ b/Teams/direct-routing/sip-options-tls-certificate-issues.md
@@ -65,7 +65,7 @@ After the TLS connection is successfully established, and the SBC is able to sen
 <details>
 <summary><b>SBC not receiving a “200 OK” response from SIP Proxy</b></summary>
 
-This situation might occur if you’re using an older version of TLS. To enforce stricter security, [enable TLS 1.2](https://docs.microsoft.com/mem/configmgr/core/plan-design/security/enable-tls-1-2).
+This situation might occur if you’re using an older version of TLS. To enforce stricter security, enable TLS 1.2.
 
 Make sure that your SBC certificate is not self-signed and that you got it from a trusted Certificate Authority (CA).
 
@@ -128,7 +128,7 @@ For more information about this process, see the ”Connect the SBC to the tenan
 
 ### TLS connection issues
 
-If the TLS connection is closed right away and SIP Options are not received from the SBC, or if 200 OK is not received from the SBC, then the problem might be with the TLS certificate. The certificate should be [version 1.2](https://docs.microsoft.com/mem/configmgr/core/plan-design/security/enable-tls-1-2) or higher.
+If the TLS connection is closed right away and SIP Options are not received from the SBC, or if 200 OK is not received from the SBC, then the problem might be with the TLS version. The TLS version configured on the SBC should be 1.2 or higher.
 
 <details>
 


### PR DESCRIPTION
The article had links on how to enable TLS 1.2 on Configuration Manager, however the change should be done on customer's SBC instead.