### PR TITLE
small fixes and clarifications

### DIFF
--- a/Teams/direct-routing/sip-options-tls-certificate-issues.md
+++ b/Teams/direct-routing/sip-options-tls-certificate-issues.md
@@ -26,7 +26,7 @@ When you set up Direct Routing, you might experience the following Session Borde
 - Session Initiation Protocol (SIP) options are not received.
 - Transport Layer Security (TLS) connections problems occur.
 - The SBC doesn’t respond.
-- The SBC is marked as inactive in the Admin portal.
+- The SBC is marked as inactive in the Teams Admin portal.
 
 Such issues are most likely caused by either or both of the following conditions:
 

--- a/Teams/direct-routing/sip-options-tls-certificate-issues.md
+++ b/Teams/direct-routing/sip-options-tls-certificate-issues.md
@@ -48,7 +48,7 @@ This article lists some common issues that are related to SIP options and TLS ce
 
 - If the SBC FQDN is detected and recognized, the SIP proxy sends a “200 OK” message by using the same TLS connection.
 
-- The SIP proxy sends SIP options to the SBC FQDN that is listed in the Contact header of the SBC SIP options.
+- The SIP proxy sends SIP options to the SBC FQDN that is listed in the Contact header of the SIP options received from the SBC.
 
 - After receiving SIP options from the SIP proxy, the SBC responds by sending a “200 OK” message. This step confirms that the SBC is healthy.
 

--- a/Teams/direct-routing/sip-options-tls-certificate-issues.md
+++ b/Teams/direct-routing/sip-options-tls-certificate-issues.md
@@ -21,7 +21,7 @@ ms.reviewer: mikebis
 
 # SBC connectivity issues
 
-When you use Direct Routing, you might experience the following Session Border Controller (SBC) connectivity issues:
+When you set up Direct Routing, you might experience the following Session Border Controller (SBC) connectivity issues:
 
 - Session Initiation Protocol (SIP) options are not received.
 - Transport Layer Security (TLS) connections problems occur.


### PR DESCRIPTION
- changed "Contact header of the SBC SIP OPTIONS" to "Contact header of the SIP OPTIONS received from the SBC", this is more clear and correct
- changed "When you use Direct Routing" to "When you set up Direct Routing", because these issues happen when the device/service is being set up, none of this is expected to break during use of the service
- changed "marked as inactive in the Admin portal" to "marked as inactive in the Teams Admin portal" to clarify and avoid confusion with any possible SBC Admin portal