### PR TITLE
Update shared-mailboxes-unexpectedly-converted-to-user-mailboxes.md

### DIFF
--- a/Exchange/ExchangeHybrid/user-and-shared-mailboxes/shared-mailboxes-unexpectedly-converted-to-user-mailboxes.md
+++ b/Exchange/ExchangeHybrid/user-and-shared-mailboxes/shared-mailboxes-unexpectedly-converted-to-user-mailboxes.md
@@ -68,7 +68,16 @@ To resolve this issue, make sure that a remote mailbox is provisioned for the ac
 
 This behavior is by design when directory synchronization is configured and the `RemoteRecipientType` attribute is set incorrectly.
 
-You can use the `New-RemoteMailbox` or `Set-RemoteMailbox` cmdlet to set the `Type` parameter of the mailbox to **Shared** with Exchange 2013 CU21 or later, Exchange 2016 CU10 or later, and Exchange 2019 and this process should only be used if you don't have Exchange 2013 or above with the latest or the previous CU or if you do but receive the error "remoteMailbox.RemoteRecipientType must include ProvisionMailbox" when changing the remote mailbox type to shared. Therefore, in order to set the attribute values correctly, the `Set-ADUser` cmdlet is required.
+> [!NOTE]
+> In the following versions of Exchange Server, you can use the `New-RemoteMailbox` or `Set-RemoteMailbox` cmdlet to set the `Type` parameter of the mailbox to **Shared**:
+>
+>- Exchange Server 2013 CU21 or later
+>- Exchange Server 2016 CU10 or later
+>- Exchange Server 2019
+>
+> For more information, see [Cmdlets to create or modify a remote shared mailbox in an on-premises Exchange environment](https://support.microsoft.com/topic/cmdlets-to-create-or-modify-a-remote-shared-mailbox-in-an-on-premises-exchange-environment-9e83fb59-c001-729c-a4c0-b2964c154b49).
+>
+> If you aren't running these versions of Exchange Server, or you continue to receive the **remoteMailbox.RemoteRecipientType must include ProvisionMailbox** error when you use the value **Shared**, use the `Set-ADUser` cmdlet. 
 
 > [!NOTE]
 > Under most circumstances, Microsoft does not support the use of non-Exchange tools to manually change Exchange attributes. Because of the limitation in these cmdlets, this behavior is identified as an exception to this support stance.

--- a/Exchange/ExchangeHybrid/user-and-shared-mailboxes/shared-mailboxes-unexpectedly-converted-to-user-mailboxes.md
+++ b/Exchange/ExchangeHybrid/user-and-shared-mailboxes/shared-mailboxes-unexpectedly-converted-to-user-mailboxes.md
@@ -68,7 +68,7 @@ To resolve this issue, make sure that a remote mailbox is provisioned for the ac
 
 This behavior is by design when directory synchronization is configured and the `RemoteRecipientType` attribute is set incorrectly.
 
-You can't use the `New-RemoteMailbox` or `Set-RemoteMailbox` cmdlet to set the `Type` parameter of the mailbox to **Shared**. Therefore, in order to set the attribute values correctly, the `Set-ADUser` cmdlet is required.
+You can use the `New-RemoteMailbox` or `Set-RemoteMailbox` cmdlet to set the `Type` parameter of the mailbox to **Shared** with Exchange 2013 CU21 or later, Exchange 2016 CU10 or later, and Exchange 2019 and this process should only be used if you don't have Exchange 2013 or above with the latest or the previous CU or if you do but receive the error "remoteMailbox.RemoteRecipientType must include ProvisionMailbox" when changing the remote mailbox type to shared. Therefore, in order to set the attribute values correctly, the `Set-ADUser` cmdlet is required.
 
 > [!NOTE]
 > Under most circumstances, Microsoft does not support the use of non-Exchange tools to manually change Exchange attributes. Because of the limitation in these cmdlets, this behavior is identified as an exception to this support stance.


### PR DESCRIPTION
Clarified the More Information section to include the New and Set-RemoteMailbox as the preferred option to do this change.