### PR TITLE
Update url-that-resides-under-root-site-collection-is-broken.md

### DIFF
--- a/SharePoint/SharePointOnline/sites/url-that-resides-under-root-site-collection-is-broken.md
+++ b/SharePoint/SharePointOnline/sites/url-that-resides-under-root-site-collection-is-broken.md
@@ -38,8 +38,6 @@ To address issues caused by deleting a root site, and to continue to allow the a
 
 - The root (top-level) site for your organization can't be deleted. Admins are no longer able to delete the root site from the SharePoint Modern Admin Center or the Manage Site Collections page in the SharePoint Admin Center. After selecting the site from the SharePoint Modern Admin Active Sites, Admins will see the **Delete** button greyed out, and hovering over the **Delete** button will inform the admin that **"The root site can't be deleted."** If you're a global or SharePoint admin in Microsoft 365, you can replace the root site with a different site.
 
-- To allow admins to manage which site is at the root, [Site Swap](/sharepoint/modern-root-site#swap-your-root-site) has been introduced. Site Swap will allow admins to replace the root site with either a modern communication site or a classic team site. 
-   > [!IMPORTANT]
-   > Site Swap is available as a PowerShell cmdlet only. For more info about using this cmdlet and what happens with the previous root site, see [Invoke-SPOSiteSwap](/powershell/module/sharepoint-online/invoke-spositeswap). Site Swap will be available in the Modern SharePoint Admin Center as a **Replace** button in future versions. 
+- To allow admins to manage which site is at the root, [Site Swap](/sharepoint/modern-root-site#swap-your-root-site) has been introduced. Site Swap will allow admins to replace the root site with a modern communication site. 
 
 Still need help? Go to [SharePoint Community](https://techcommunity.microsoft.com/t5/sharepoint/ct-p/SharePoint).


### PR DESCRIPTION
We have removed support swapping Classic Sites to the root. In addition, the Replace button is now available for the majority of customers.