### PR TITLE
fix description in "Cause" section

### DIFF
--- a/Exchange/ExchangeOnline/antispam-and-protection/cannot-send-emails-to-external-recipients.md
+++ b/Exchange/ExchangeOnline/antispam-and-protection/cannot-send-emails-to-external-recipients.md
@@ -27,7 +27,7 @@ When users try to send mail from Microsoft Exchange Online or Microsoft Exchange
 
 ## Cause
 
-The recipient server requires that the server name that's contained in the message HELO string have a corresponding pointer (PTR) resource record (reverse IP lookup). Exchange Online and Exchange Online Protection use multiple IP addresses to send mail. Because of DNS limitations, all these IP addresses can be mapped through the PTR record to the server name that's in the message HELO string.
+The recipient server requires that the server name that's contained in the message HELO string have a corresponding pointer (PTR) resource record (reverse IP lookup). Exchange Online and Exchange Online Protection use multiple IP addresses to send mail. Because of DNS limitations, all these IP addresses can't be mapped through the PTR record to the server name that's in the message HELO string.
 
 ## Resolution
 


### PR DESCRIPTION
Quote: "Because of DNS limitations, all these IP addresses **can** be mapped through the PTR record to the server name that's in the message HELO string." 

While one single IP address can have multiple FQDNs/domain names, a single IP address should have a single corresponding pointer (PTR) resource record (reverse IP lookup) pointing to the primary domain name ( see [RFC 1035 Domain Implementation and Specification](https://tools.ietf.org/html/rfc1035#section-3.5) and [see this stack exchange question](https://serverfault.com/questions/618700/why-multiple-ptr-records-in-dns-is-not-recommended) ) . Thus the quoted sentence is incorrect. That's  the DNS limitation this article ia all about. I guess it's just a typo. Greetings.