### PR TITLE
Update group-calendar-shows-all-user-free-busy-info.md

### DIFF
--- a/Exchange/ExchangeOnline/outlook-issues/group-calendar-shows-all-user-free-busy-info.md
+++ b/Exchange/ExchangeOnline/outlook-issues/group-calendar-shows-all-user-free-busy-info.md
@@ -40,10 +40,7 @@ When you do this, the Office 365 modern group is treated as a distribution list,
 
 To resolve this issue, follow these steps to open the Office 365 modern group calendar:
 
-1. Open your Inbox folder, expand **Groups** in the folder list, and then select the modern group.
-2. Select **Calendar** on the ribbon.
-3. Right-click the calendar name in the navigation pane, and then select **Add to Favorites**.
-4. Close the modern group calendar window.
-5. Open the **Calendar** view in Outlook. You will find the modern group calendar listed under **My Calendars**, and the issue will not occur when you view the calendar.
+1. Open your **Outlook** , expand **All Group Calendars** , and then select the modern group.
+2. The issue will not occur when you view the calendar.
 
 Still need help? Go to [Microsoft Community](https://answers.microsoft.com/).

--- a/Exchange/ExchangeOnline/outlook-issues/group-calendar-shows-all-user-free-busy-info.md
+++ b/Exchange/ExchangeOnline/outlook-issues/group-calendar-shows-all-user-free-busy-info.md
@@ -38,9 +38,10 @@ When you do this, the Office 365 modern group is treated as a distribution list,
 
 ## Resolution
 
-To resolve this issue, follow these steps to open the Office 365 modern group calendar:
+To resolve this issue, open the Office 365 modern group calendar in the following way:
 
-1. Open your **Outlook** , expand **All Group Calendars** , and then select the modern group.
-2. The issue will not occur when you view the calendar.
+Open the **Calendar** view in Outlook, expand **All Group Calendars**, and then select the modern group.
+
+The issue won't occur when you view the calendar.
 
 Still need help? Go to [Microsoft Community](https://answers.microsoft.com/).


### PR DESCRIPTION
Made changes to the navigation as Add to favorites is no longer available when you select a group calendar.