### PR TITLE
Update proxy-address-being-used.md

### DIFF
--- a/Exchange/ExchangeOnline/administration/proxy-address-being-used.md
+++ b/Exchange/ExchangeOnline/administration/proxy-address-being-used.md
@@ -55,6 +55,10 @@ To determine which objects share the proxy address of a specified user, follow t
 
 Only one proxy address at a time can be assigned to an object. After you determine which object is in conflict, you can remove or change the proxy address that's associated with that object.
 
+## Error when creating shared mailboxes
+
+If you see the error message, **The proxy address "smtp:<shared mailbox name\>" is already being used by the proxy addresses or LegacyExchangeDN of "\<name>". Please choose another proxy address**, it means you're trying to give the shared mailbox a name that's already in use. For example, let's say you want shared mailboxes named info@domain1 and info@domain2. In such cases name the second shared mailbox something different from the start to get around the error. Then in the admin center, rename the shared mailbox to what you want it to be.
+
 ## More information
 
 For more information about primary addresses and proxy addresses, see [Add or remove email addresses for a mailbox](/exchange/recipients-in-exchange-online/manage-user-mailboxes/add-or-remove-email-addresses).

--- a/Exchange/ExchangeOnline/administration/proxy-address-being-used.md
+++ b/Exchange/ExchangeOnline/administration/proxy-address-being-used.md
@@ -16,7 +16,7 @@ search.appverid:
 appliesto:
 - Exchange Online
 ---
-# (Proxy address  is already being used) error message in Exchange Online
+# "Proxy address is already being used" error message in Exchange Online
 
 ## Problem
 
@@ -55,12 +55,11 @@ To determine which objects share the proxy address of a specified user, follow t
 
 Only one proxy address at a time can be assigned to an object. After you determine which object is in conflict, you can remove or change the proxy address that's associated with that object.
 
-## Error when creating shared mailboxes
-
-If you see the error message, **The proxy address "smtp:<shared mailbox name\>" is already being used by the proxy addresses or LegacyExchangeDN of "\<name>". Please choose another proxy address**, it means you're trying to give the shared mailbox a name that's already in use. For example, let's say you want shared mailboxes named info@domain1 and info@domain2. In such cases name the second shared mailbox something different from the start to get around the error. Then in the admin center, rename the shared mailbox to what you want it to be.
+To resolve this issue when creating shared mailboxes, see [Error when creating shared mailboxes](/microsoft-365/admin/email/resolve-issues-with-shared-mailboxes?view=o365-worldwide#error-when-creating-shared-mailboxes&preserve-view=true).
 
 ## More information
 
 For more information about primary addresses and proxy addresses, see [Add or remove email addresses for a mailbox](/exchange/recipients-in-exchange-online/manage-user-mailboxes/add-or-remove-email-addresses).
 
 Still need help? Go to [Microsoft Community](https://answers.microsoft.com/).
+


### PR DESCRIPTION
Added a workaround when there are multiple domains in the office365 tenant, the same error occurs for shared mailboxes with the same name.

reference:- https://docs.microsoft.com/en-us/microsoft-365/admin/email/resolve-issues-with-shared-mailboxes?view=o365-worldwide