### PR TITLE
Update cannot-access-mailbox.md

### DIFF
--- a/Exchange/ExchangeHybrid/user-and-shared-mailboxes/cannot-access-mailbox.md
+++ b/Exchange/ExchangeHybrid/user-and-shared-mailboxes/cannot-access-mailbox.md
@@ -114,7 +114,7 @@ Create an on-premises object for the cloud mailbox by using the `New-RemoteMailb
 For example, run the following command:  
 
 ```powershell
-New-Remotemailbox sharedmailbox@contoso.com -Remoteroutingaddress sharedmailbox@contoso.mail.onmicrosoft.com -Shared
+New-Remotemailbox -Name "Shared mailbox" -Alias sharedmailbox -UserPrincipleName sharedmailbox@contoso.com -Remoteroutingaddress sharedmailbox@contoso.mail.onmicrosoft.com -Shared
 ```
 
 ## More information


### PR DESCRIPTION
As mentioned in the article, the Onprem object must have the same name, alias, and user principal name (UPN) as the cloud mailbox. Updated the Syntax for the powershell example to reflect this. The original example fails as it sets the UPN as the Alias and causes the object to have incorrect properties.