### PR TITLE
Removing engines other than Microsoft from Doc

### DIFF
--- a/Exchange/ExchangeServer/setup/manually-update-scan-engines.md
+++ b/Exchange/ExchangeServer/setup/manually-update-scan-engines.md
@@ -29,10 +29,6 @@ Follow the steps given below to manually update the scan engines in Exchange Ser
 
 The manual update involves running the Update-Engines.ps1 PowerShell script. This script can be changed according to your needs. The update path, list of engines, and list of platforms can be changed in the script, or passed as parameters when the script is executed.
 
-When defining a specific engine(s), you must use the following naming convention for AMD64:
-
-Microsoft, Command, VBuster, Kaspersky, Norman, Wormlist, Cloudmark
-
 > [!NOTE]
 > The script will default the engine update path to `https://forefrontdl.microsoft.com/server/scanengineupdate/`. If this endpoint isn't available, it'll use the failover endpoint `https://amupdatedl.microsoft.com/server/scanengineupdate/`. By default, all engines will be downloaded for 64-bit platforms.
 
@@ -66,7 +62,7 @@ Microsoft, Command, VBuster, Kaspersky, Norman, Wormlist, Cloudmark
     [string]$EngineDirPath,
     [string]$UpdatePathUrl = "http://forefrontdl.microsoft.com/server/scanengineupdate/",
     [string]$FailoverPathUrl = "https://amupdatedl.microsoft.com/server/scanengineupdate/",
-    [string[]]$Engines = ("Microsoft", "Norman", "Command", "VBuster", "Kaspersky", "WormList", "Cloudmark"),
+    [string[]]$Engines = ("Microsoft"),
     [string[]]$Platforms = ("amd64")
     )
 


### PR DESCRIPTION
This change aims to remove any mention of other engines like Kaspersky, command from the doc. There should be presence of only one engine viz Microsoft.