### PR TITLE
Update office-365-notice.md

### DIFF
--- a/Exchange/ExchangeOnline/email-delivery/office-365-notice.md
+++ b/Exchange/ExchangeOnline/email-delivery/office-365-notice.md
@@ -60,9 +60,9 @@ Additionally, you must meet the second condition ("certificate-based connector 
 - Your organization has to send messages from the email server in your on-premises environment from domains that your organization hasn't added to Office 365. For example, your organization (contoso.com) sends email as the fabrikam.com domain, and fabrikam.com doesn't belong to your organization.
 - A forwarding rule is configured on your on-premises server, and messages are relayed through Office 365.
 
-    For example, contoso.com is your organization's domain. A user on your organization's on-premises server, kate@contoso.com, enables forwarding for all messages to kate@contoso.com. When john@fabrikam.com sends a message to kate@contoso.com, the message is automatically forwarded to kate@contoso.com.
+    For example, contoso.com is your organization's domain. A user on your organization's on-premises server, kate@contoso.com, enables forwarding for all messages to kate@tailspintoys.com. When john@fabrikam.com sends a message to kate@contoso.com, the message is automatically forwarded to kate@tailspintoys.com.
 
-    From the point of view of Office 365, the message is sent from john@fabrikam.com to  kate@contoso.com. Because Kate's mail is forwarded, neither the sender domain nor the recipient domain belongs to your organization.
+    From the point of view of Office 365, the message is sent from john@fabrikam.com to kate@tailspintoys.com. Because Kate's mail is forwarded, neither the sender domain nor the recipient domain belongs to your organization.
   
 ![email forwarding](./media/office-365-notice/email-forwarding.png)
 


### PR DESCRIPTION
Please revert the recent change 664d82d for this file. The domain "tailspintoys.com" should not be changed to "contoso.com" in this particular context. The example of lines 63-65 talks about forwarding from contoso to tailspintoys. This becomes meaningless if we replace tailspintoys with contoso.