### PR TITLE
Updated SQL Database Compatibility for SP installations to add Subscription Edition info

### DIFF
--- a/SharePoint/SharePointServer/administration/sql-database-compatibility-for-sharepoint-installation.md
+++ b/SharePoint/SharePointServer/administration/sql-database-compatibility-for-sharepoint-installation.md
@@ -12,29 +12,34 @@ ms.custom:
   - CSSTroubleshoot
 ms.reviewer: sudeepg, troymoen, shaunbe, pelopes, sureshka, josack, alexek, rainera, abloesch, jopilov
 appliesto:
+- SQL Server 2019 on Windows
 - SQL Server 2017 on Windows
 - SQL Server 2016
+- SharePoint Server Subscription Edition
+- SharePoint Server 2019
 - SharePoint Server 2016
 search.appverid: MET150
 ---
-# Supported SQL Server database compatibility level for SharePoint Server 2016 installations
+# Supported SQL Server database compatibility level for SharePoint Server installations
 
 _Original KB number:_ &nbsp; 4469993
 
 ## Symptom
 
-When you use SharePoint Server 2016 together with Microsoft SQL Server version 2016 or 2017, you may notice decreased query performance or increased CPU usage on the database server.
+When you use SharePoint Server together with Microsoft SQL Server, you may notice decreased query performance or increased CPU usage on the database server.
 
 ## Cause
 
-This issue happens because content databases that are created by SharePoint Server 2016 use the default database compatibility level for the version of SQL Server that the database is installed on. For example, if the SharePoint databases are deployed in an instance of SQL Server 2016, the databases are set to the 130 database compatibility level. Similarly, in an instance of SQL Server 2017, the databases are set to the 140 database compatibility level.
+This issue happens because content databases that are created by SharePoint Server use the default database compatibility level for the version of SQL Server that the database is installed on. For example, if SharePoint databases are deployed in an instance of SQL Server 2016, the databases are set to the 130 database compatibility level. Similarly, in an instance of SQL Server 2017, the databases are set to the 140 database compatibility level.
 
 ## Workaround
 
-SharePoint Server 2016 content databases that are deployed on SQL Server versions 2016 and 2017 are tested and validated to work best with compatibility level 110. Therefore, we strongly recommend that you set the database compatibility level to 110 for SharePoint Server 2016 content databases. To change the compatibility level, run the following TSQL command:
+SharePoint Server content databases that are deployed on SQL Server versions are tested and validated to work best with a specific database compatibility level. Therefore, we strongly recommend that you set the database compatibility level to 110 for SharePoint Server 2016 content databases, 130 for SharePoint Server 2019 content databases and 150 for SharePoint Server Subscription Edition content databases.
+
+To change the compatibility level, run the following TSQL command:
 
 ```sql
-ALTER DATABASE database_nameSET COMPATIBILITY_LEVEL = 110
+ALTER DATABASE database_nameSET COMPATIBILITY_LEVEL = 130
 ```
 
 You can view the compatibility level of all the databases in an instance of SQL Server by using the following TSQL query:
@@ -51,6 +56,7 @@ The following table shows the supported database compatibility levels to use for
 |---|---|
 | SharePoint Server 2016| 110 |
 | SharePoint Server 2019| 130 |
+| SharePoint Server Subscription Edition| 150 |
 |||
 
 For more information about database compatibility during version upgrades and a list of default and supported database compatibility levels for each version of SQL Server, see [ALTER DATABASE (Transact-SQL) compatibility level](/sql/t-sql/statements/alter-database-transact-sql-compatibility-level) on the Microsoft Docs website.


### PR DESCRIPTION
I updated the [this article](https://docs.microsoft.com/en-US/sharepoint/troubleshoot/administration/sql-database-compatibility-for-sharepoint-installation) to make it less version specific (specifically named SP2016 in the title, but also mentions SP2019) and added SharePoint Subscription Edition information.