### PR TITLE
added 'room list' step to workspace instructions

### DIFF
--- a/Exchange/ExchangeOnline/outlook-issues/create-book-workspace-outlook.md
+++ b/Exchange/ExchangeOnline/outlook-issues/create-book-workspace-outlook.md
@@ -51,10 +51,17 @@ Creating a workspace is similar to configuring a room. The difference is that yo
 
     **Note**:  
     In hybrid environments, this cmdlet doesn't work on the following properties of synchronized room mailboxes: **City**, **CountryOrRegion**, **GeoCoordinates**, **Phone**, **PostalCode**, **State**, and **Street**. To modify these properties, use the `Set-User` or `Set-Mailbox` cmdlet in Exchange Server (on-premises).
-3. To show a workspace in a particular building, add the workspace to an appropriate room list (distribution group):
+
+3. To show a workspace in a specific building, create a room list (distribution group):
 
     ```powershell
-    Add-DistributionGroupMember -Identity "Building 32" -Member <wkspace3223@contoso.com>  
+    New-DistributionGroup -Name "Building 32" -Members wkspace3223@contoso.com, wkpsace3224@contoso.com -RoomList
+    ```
+
+    Alternatetly, add the workspace to an existing room list (distribution group):
+
+    ```powershell
+    Add-DistributionGroupMember -Identity "Building 32" -Member wkspace3223@contoso.com  
     ```
 
 4. Enforce the workspace capacity, and specify a minimum reservation duration for workspace booking.


### PR DESCRIPTION
Please consider updating the docs with this edit or something similar. I've added a step for creating a room list. The omission of this step has led to workspaces created, but not visible in the room finder because the creator did not know to use the '-RoomList' flag when creating the building distribution group.