### PR TITLE
Update recommendation for SharePoint's Trusted Sites zones

### DIFF
--- a/SharePoint/SharePointOnline/administration/troubleshoot-mapped-network-drives.md
+++ b/SharePoint/SharePointOnline/administration/troubleshoot-mapped-network-drives.md
@@ -81,7 +81,6 @@ Make sure that the SharePoint Online URLs have been added to your Trusted sites 
    > [!NOTE]
    > We recommend that you also add the following Office 365 URLs to the Trusted sites zone:
    >
-   > - https://*.sharepoint.com
    > - https://*.microsoftonline.com
    > - https://*.microsoft.com
 


### PR DESCRIPTION
Remove `*.sharepoint.com` from the list of recommended Trusted Sites domains. Customers should only specify their own fully-qualified domain as described in the preceding paragraph (`contoso.sharepoint.com` not `*.sharepoint.com`).