### PR TITLE
Update dynamic-distribution-group-members-not-receive-emails.md

### DIFF
--- a/Exchange/ExchangeHybrid/groups-and-distribution-lists/dynamic-distribution-group-members-not-receive-emails.md
+++ b/Exchange/ExchangeHybrid/groups-and-distribution-lists/dynamic-distribution-group-members-not-receive-emails.md
@@ -30,7 +30,7 @@ Additionally, if you run a command such as the following to return a list of rec
 
 ```console
 $list = Get-DynamicDistributionGroup sales@contoso.com  
-Get-Recipient -RecipientPreviewFilter $list.RecipientFilter
+Get-Recipient -RecipientPreviewFilter $list.RecipientFilter -OrganizationalUnit $list.RecipientContainer
 ```
 
 ## Cause
@@ -50,6 +50,6 @@ Set-DynamicDistributionGroup -Identity sales@contoso.com -RecipientFilter {(Reci
 
 ## More information
 
-For more information, see [Set-DynamicDistributionGroup](/powershell/module/exchange/set-dynamicdistributiongroup).
+For more information, see [Get-DynamicDistributionGroup](/powershell/module/exchange/get-dynamicdistributiongroup) and [Set-DynamicDistributionGroup](/powershell/module/exchange/set-dynamicdistributiongroup).
 
 Still need help? Go to [Microsoft Community](https://answers.microsoft.com/) or the [Exchange TechNet Forums](/answers/topics/office-exchange-server-itpro.html).


### PR DESCRIPTION
Hello,
I would like to update the powershell command which list the receipients of the dynamic distribution group. Without the parameter `-OrganizationalUnit` the command might return a wrong list of receipient.

Additional I added a link to find more information about the command `Get-DynamicDistributionGroup` 