### PR TITLE
Update access-linked-table-deleted.md

### DIFF
--- a/Office/Client/access/access-linked-table-deleted.md
+++ b/Office/Client/access/access-linked-table-deleted.md
@@ -25,7 +25,7 @@ ms.date: 3/31/2022
 
 A Microsoft Access-linked table that contains one or more **datetime** or **datetime2** columns and that’s connected to a Microsoft SQL Server database and has a compatibility level of 130 or larger (the compatibility level for SQL Server 2016) returns **#Deleted** in the results.
 
-When you try to commit record changes to the linked table, you may also receive the following "Write Conflict" message:
+When you try to commit record changes to the linked table, you may also receive the following **"Write Conflict"** message:
 
 > This record has been changed by another user since you started editing it.
 
@@ -49,9 +49,6 @@ To improve syntax compatibility with SQL, and to increase the accuracy and level
 > The **Date & Time Extended** data type isn't compatible with previous versions of Microsoft Access. As a result, if the data type is implemented within a local Access table and the Access database is used with a previous version that doesn't include this feature, you can't open the database.
 
 You can enable or disable the **Date & Time Extended** data type for linking and importing operations by using the **Current Database** Access option **Support Date Time Extended (DateTime2) Data Type for Linked/lmported Tables**. For more information, see [Set user options for the current database](https://support.microsoft.com/office/set-user-options-for-the-current-database-29b6b7be-4c3b-43a7-b8f0-5e1c68f5adce).
-
-> [!NOTE]
-> Access currently doesn't support the use of **Date & Time Extended** as part of the unique identifier/primary key of the linked ODBC table. If one or more of the columns that make up the unique identifier of the linked table use the **Date & Time Extended** data type, and the date includes fractional seconds, the record may appear as **#Deleted**. 
 
 For earlier versions of Access, use one of the following methods to work around this issue:
 


### PR DESCRIPTION
Access added support for using datetime and datetime2 data types which contain fractional seconds to be allowed within the column(s) that make up the table's unique record identifier.