### PR TITLE
Modify  -CountryOrRegion flag for Set-Place references

### DIFF
--- a/Outlook/Client/calendaring/configure-room-finder-rooms-workspaces.md
+++ b/Outlook/Client/calendaring/configure-room-finder-rooms-workspaces.md
@@ -78,7 +78,7 @@ For example, consider that for an organization that uses *contoso.com* as the do
     ```powershell
     New-Mailbox -Organization contoso.com -Name room1 -DisplayName "Conference Room 1" -Room
     
-    Set-Place room1@contoso.com -CountryOrRegion "United States of America" -State "Washington" -City "Seattle" -Floor 1 -FloorLabel “Ground” -Capacity 5
+    Set-Place room1@contoso.com -CountryOrRegion "US" -State "Washington" -City "Seattle" -Floor 1 -FloorLabel “Ground” -Capacity 5
     ```
 
 **Note**: In the Set-Place cmdlet,use the **Floor** property to specify the floor where a room or workspace is located. In the Places API room resource type, use the **FloorNumber** parameter.
@@ -88,7 +88,7 @@ For example, consider that for an organization that uses *contoso.com* as the do
     ```powershell
     New-Mailbox -Organization contoso.com -Name workspace1 -DisplayName "Workspace 1" -Room | Set-Mailbox -Type Workspace 
     
-    Set-Place workspace1@contoso.com -CountryOrRegion "United States of America" -State "Washington" -City "Seattle" -Floor 1 -FloorLabel "Ground" -Capacity 5
+    Set-Place workspace1@contoso.com -CountryOrRegion "US" -State "Washington" -City "Seattle" -Floor 1 -FloorLabel "Ground" -Capacity 5
     ```
 
     Also, you can set up automatic workspace capacity evaluation by running the following cmdlet:


### PR DESCRIPTION
This article is currently written to have the operator leverage the noun `United States of America` for the country code. Looking at the `Set-Place` official documentation, you can see that this is supposed to be a two character country code. https://learn.microsoft.com/en-us/powershell/module/exchange/set-place?view=exchange-p

When trying to use this code without using the two character country code, I got the below error. 

![image](https://github.com/MicrosoftDocs/OfficeDocs-Support/assets/67766491/a661f64e-8d43-4c38-8fc7-32424bdce4fd)

`Set-Place: Cannot process argument transformation on parameter 'CountryOrRegion'. Cannot convert value "United States of America" to type "Microsoft.Exchange.Data.Directory.Coun trylnfo".
Error: "The ISO-3166 2-letter country/region code or friendly name "United States of America" does not represent a country/region."`

