### PR TITLE
Update o365-group-tasks.md

### DIFF
--- a/Exchange/ExchangeOnline/groups-and-distribution-lists/o365-group-tasks.md
+++ b/Exchange/ExchangeOnline/groups-and-distribution-lists/o365-group-tasks.md
@@ -355,7 +355,7 @@ Deleted Microsoft 365 groups are retained for 30 days. Within this period, eithe
 Restoring a Microsoft 365 group restores any services that are related to the group, such as Planner, Teams, and SharePoint sites.
 
 > [!NOTE]
-> It may take several hours to restore all the associated content for a group.
+> It may take up to 48 hours to restore all the associated content for a group.
 
 #### For group owners
 


### PR DESCRIPTION
S500 customer (MASTERCARD) on case 2408140040010765001 has requested to update this documentation as the operation can take up to 48 hours to be completed. 

The customer would like to have the documentation explicitly saying 48 hrs, or up to 2 days:

Customer statement:
Currently, the document states "several hours" instead of "up to 48hrs" or "up to 2 days".