### PR TITLE
Update "Microsoft and SIP response codes" public documentation with additional response codes

### DIFF
--- a/Teams/phone-system/direct-routing/microsoft-sip-response-codes-403.md
+++ b/Teams/phone-system/direct-routing/microsoft-sip-response-codes-403.md
@@ -21,7 +21,7 @@ ms.reviewer: teddygyabaah
 
 # SIP response code 403
 
-This article provides troubleshooting information for various combinations of the SIP 403 error and Microsoft response codes.
+This article provides troubleshooting information for various combinations of the "SIP 403" error and Microsoft response codes.
 
 ## 10199 403 Call rejected as private calling is disabled for the callee
 
@@ -42,8 +42,8 @@ This article provides troubleshooting information for various combinations of th
 - Microsoft response code: **10553**
 - SIP response code: **403**
 - Suggested actions:  
-  - Verify that [compliance recording](/microsoftteams/teams-recording-policy) is set up correctly, including provisioning of the recorder bot.
-  - Work with the compliance recording partner who provides the recorder service to check why the bot can't be invited.
+  - Verify that [compliance recording](/microsoftteams/teams-recording-policy) is set up correctly. This includes provisioning of the recorder bot.
+  - Work together with the compliance recording partner who provides the recorder service to check why the bot can't be invited.
   
 ## 510532 403 Get Inbound Direct routing - RuntimeApi trunk config not found for customer
 
@@ -71,7 +71,7 @@ This article provides troubleshooting information for various combinations of th
 - Microsoft response code: **510546**
 - SIP response code: **403**
 - Suggested actions:
-  - If Location Based Routing feature is being used, this error might be by design that the user is not allowed to make calls from their current site, but in other cases could be caused by misconfiguration as well. Verify that LBR for Direct Routing is configured correctly. For more information about LBR configuration, see [Plan Location Based Routing](https://learn.microsoft.com/en-us/microsoftteams/location-based-routing-plan).
+  - If the Location Based Routing feature is used, this error message might be by design to indicate that the user is not allowed to make calls from their current site. However, in other cases, this error could be caused by a misconfiguration. Verify that LBR for Direct Routing is configured correctly. For more information about LBR configuration, see [Plan Location Based Routing](https://learn.microsoft.com/en-us/microsoftteams/location-based-routing-plan).
   - If Direct Routing is not used at all, then it's most likely a misconfiguration of Teams Calling Policy and PreventTollBypass is set to True, for more information, see [Set-CsTeamsCallingPolicy](https://learn.microsoft.com/en-us/powershell/module/teams/set-csteamscallingpolicy?view=teams-ps#-preventtollbypass). 
 
 ## 510560 403 User is not Enterprise Voice enabled
@@ -93,7 +93,7 @@ This article provides troubleshooting information for various combinations of th
 - Microsoft response code: **510562**
 - SIP response code: **403**
 - Suggested actions:  
-  - Verify that the affected user is assigned a Phone System license and is correctly [enabled for Direct Routing](/microsoftteams/direct-routing-enable-users). For more information about issues with outbound calls, see [Issues that affect outbound Direct Routing calls](/microsoftteams/troubleshoot/phone-system/direct-routing/issues-with-outbound-calls).
+  - Verify that the affected user is assigned a Phone System license and is correctly [enabled for Direct Routing](/microsoftteams/direct-routing-enable-users). For more information about issues that affect outbound calls, see [Issues that affect outbound Direct Routing calls](/microsoftteams/troubleshoot/phone-system/direct-routing/issues-with-outbound-calls).
 
 ## 510563 403 User is only allowed to make domestic calls. This is an international call
 
@@ -114,4 +114,4 @@ This article provides troubleshooting information for various combinations of th
 - Microsoft response code: **510559**
 - SIP response code: **403**
 - Suggested actions:  
-  - Make sure that the dialed number in Teams matches a corresponding number pattern in a voice route for the given user. In some cases, this error occurs because an incorrect number is dialed, or the customer's own internal policy prevents calls to specific countries/regions, or number patterns.
+  - Make sure that the dialed number in Teams matches a corresponding number pattern in a voice route for the given user. In some cases, this error occurs because an incorrect number is dialed, or the customer's own internal policy prevents calls to specific countries, regions, or number patterns.

--- a/Teams/phone-system/direct-routing/microsoft-sip-response-codes-403.md
+++ b/Teams/phone-system/direct-routing/microsoft-sip-response-codes-403.md
@@ -66,6 +66,14 @@ This article provides troubleshooting information for various combinations of th
 - Suggested actions:  
   - Check the [inbound call blocking settings](/microsoftteams/block-inbound-calls) for blocked caller numbers.
 
+## 510546 403 Get Outbound Direct routing - no trunk config found by LBR selection criteria
+
+- Microsoft response code: **510546**
+- SIP response code: **403**
+- Suggested actions:
+  - If Location Based Routing feature is being used, this error might be by design that the user is not allowed to make calls from their current site, but in other cases could be caused by misconfiguration as well. Verify that LBR for Direct Routing is configured correctly. For more information about LBR configuration, see [Plan Location Based Routing](https://learn.microsoft.com/en-us/microsoftteams/location-based-routing-plan).
+  - If Direct Routing is not used at all, then it's most likely a misconfiguration of Teams Calling Policy and PreventTollBypass is set to True, for more information, see [Set-CsTeamsCallingPolicy](https://learn.microsoft.com/en-us/powershell/module/teams/set-csteamscallingpolicy?view=teams-ps#-preventtollbypass). 
+
 ## 510560 403 User is not Enterprise Voice enabled
 
 - Microsoft response code: **510560**

--- a/Teams/phone-system/direct-routing/microsoft-sip-response-codes-488.md
+++ b/Teams/phone-system/direct-routing/microsoft-sip-response-codes-488.md
@@ -21,7 +21,7 @@ ms.reviewer: teddygyabaah
 
 # SIP response code 488
 
-This article provides troubleshooting information for various combinations of the SIP 488 error and Microsoft response codes.
+This article provides troubleshooting information for various combinations of the "SIP 488" error and Microsoft response codes.
 
 ## 531000 488 InternalDiagCode: CannotSupportAnyMedia, InternalErrorPhrase: Invalid SDP offer: no media acceptable
 
@@ -49,4 +49,4 @@ This article provides troubleshooting information for various combinations of th
 - Microsoft response code: **531052**
 - SIP response code: **488**
 - Suggested actions:
-  - SBC sent SIP message with SDP that has a connection address of 0.0.0.0. This is not supported by Microsoft SIP stack. For more information about deviations from the RFCs, see [Direct Routing - Deviations from the RFCs](https://learn.microsoft.com/en-us/microsoftteams/direct-routing-protocols#deviations-from-the-rfcs). 
+  - SBC sent a SIP message with SDP that has a connection address of 0.0.0.0. This is not supported by Microsoft SIP stack. For more information about deviations from the RFCs, see [Direct Routing - Deviations from the RFCs](https://learn.microsoft.com/en-us/microsoftteams/direct-routing-protocols#deviations-from-the-rfcs). 

--- a/Teams/phone-system/direct-routing/microsoft-sip-response-codes-488.md
+++ b/Teams/phone-system/direct-routing/microsoft-sip-response-codes-488.md
@@ -43,3 +43,10 @@ This article provides troubleshooting information for various combinations of th
 - SIP response code: **488**
 - Suggested actions:  
   - Media bypass doesn't work if the SBC doesn't provide any ICE candidates in its SDP offer. Make sure that you enable ICE Lite on the SBC. For more information about media bypass, see [About Media Bypass with Direct Routing](/microsoftteams/direct-routing-plan-media-bypass#about-media-bypass-with-direct-routing) and [Direct Routing - media protocols](/microsoftteams/direct-routing-protocols-media).
+ 
+## 531052 488 Cannot negotiate a new modality with blackhole media
+
+- Microsoft response code: **531052**
+- SIP response code: **488**
+- Suggested actions:
+  - SBC sent SIP message with SDP that has a connection address of 0.0.0.0. This is not supported by Microsoft SIP stack. For more information about deviations from the RFCs, see [Direct Routing - Deviations from the RFCs](https://learn.microsoft.com/en-us/microsoftteams/direct-routing-protocols#deviations-from-the-rfcs). 

--- a/Teams/phone-system/direct-routing/microsoft-sip-response-codes-503.md
+++ b/Teams/phone-system/direct-routing/microsoft-sip-response-codes-503.md
@@ -21,7 +21,7 @@ ms.reviewer: teddygyabaah
 
 # SIP response code 503
 
-This article provides troubleshooting information for various combinations of the SIP 503 error and Microsoft response codes.
+This article provides troubleshooting information for various combinations of the "SIP 503" error and Microsoft response codes.
 
 ## 10320 503 Bot is unreachable or unable to answer before timeout
 
@@ -29,14 +29,14 @@ This article provides troubleshooting information for various combinations of th
 - SIP response code: 503
 - Suggested actions:  
   - If the bot is provided by Microsoft, such as the built-in call recording, [contact Microsoft Support](https://support.microsoft.com/contactus).
-  - If the bot is your own bot or from a third-party provider, work with the bot provider to verify that the bot is set up correctly.
+  - If the bot is your own bot or is provided by a third-party provider, work with the bot provider to verify that the bot is set up correctly.
 
 ## 540998 503 Service Unavailable - Service state: Inactive/DrainingTransactions
 
 - Microsoft response code: **540998**
 - SIP response code: **503**
 - Suggested actions:
-  - Expected reject during offloading of Microsoft SIP end points for maintenance. The Microsoft SIP Signaling FQDNs point to available endpoints enough time in advance for the SBC to resolve the FQDNs to new endpoints and send traffic to these, so there shouldn't be too many errors like this in normal circumstances. However, if there are many of these errors, it might make sense to check SBC configuration, if it resolves DNS often enough to not send SIP requests to inactive/shutting down Microsoft end points. Ideally it should be resolved every 15 minutes or less.
+  - Expected reject during offloading of Microsoft SIP end points for maintenance. The Microsoft SIP Signaling FQDNs point to available endpoints far enough in advance for the SBC to resolve the FQDNs to new endpoints and send traffic to them. Therefore, few errors such as this should occur under the usual circumstances. However, if many of these errors do occur, we recommend that you check that the SBC configuration resolves DNS often enough not to send SIP requests to inactive or shut down Microsoft end points. Ideally, DNS should be resolved every 15 minutes or more frequently.
 
 ## 560503 503 Service unavailable. SBC undergoing maintenance or temporarily overloaded
 
@@ -45,4 +45,4 @@ This article provides troubleshooting information for various combinations of th
 - Suggested actions:  
   - Check the logs on the SBC to investigate why it returns the "503" SIP response.
   - Make sure that the SBC is correctly licensed to handle the number of concurrent sessions.
-  - Determine whether the "503" error is related to a specific destination country/region or calling corridor.
+  - Determine whether the "503" error is related to a specific destination country, region, or calling corridor.

--- a/Teams/phone-system/direct-routing/microsoft-sip-response-codes-503.md
+++ b/Teams/phone-system/direct-routing/microsoft-sip-response-codes-503.md
@@ -31,6 +31,13 @@ This article provides troubleshooting information for various combinations of th
   - If the bot is provided by Microsoft, such as the built-in call recording, [contact Microsoft Support](https://support.microsoft.com/contactus).
   - If the bot is your own bot or from a third-party provider, work with the bot provider to verify that the bot is set up correctly.
 
+## 540998 503 Service Unavailable - Service state: Inactive/DrainingTransactions
+
+- Microsoft response code: **540998**
+- SIP response code: **503**
+- Suggested actions:
+  - Expected reject during offloading of Microsoft SIP end points for maintenance. The Microsoft SIP Signaling FQDNs point to available endpoints enough time in advance for the SBC to resolve the FQDNs to new endpoints and send traffic to these, so there shouldn't be too many errors like this in normal circumstances. However, if there are many of these errors, it might make sense to check SBC configuration, if it resolves DNS often enough to not send SIP requests to inactive/shutting down Microsoft end points. Ideally it should be resolved every 15 minutes or less.
+
 ## 560503 503 Service unavailable. SBC undergoing maintenance or temporarily overloaded
 
 - Microsoft response code: **560503**

--- a/Teams/phone-system/direct-routing/microsoft-sip-response-codes-504.md
+++ b/Teams/phone-system/direct-routing/microsoft-sip-response-codes-504.md
@@ -21,7 +21,7 @@ ms.reviewer: teddygyabaah
 
 # SIP response code 504
 
-This article provides troubleshooting information for various combinations of the SIP 504 error and Microsoft response codes.
+This article provides troubleshooting information for various combinations of the "SIP 504" error and Microsoft response codes.
 
 ## 549002 504 Unable to deliver INVITE: TlsTransport is not connected, State=Disconnected
 
@@ -29,7 +29,7 @@ This article provides troubleshooting information for various combinations of th
 - SIP response code: **504**
 - Suggested actions:  
   - Check whether the Session Border Controller (SBC) is functional.
-  - Check whether the SBC is reachable through the specific IP and port. Also, check your firewall settings to make sure that connection to SBC isn't blocked.
+  - Check whether the SBC is reachable through the specified IP and port. Also, check your firewall settings to make sure that connectivity to SBC isn't blocked.
 
 ## 549002 504 Unable to deliver INVITE: Invalid Request/Response line
 
@@ -43,7 +43,7 @@ This article provides troubleshooting information for various combinations of th
 - Microsoft response code: **549018**
 - SIP response code: **504**
 - Suggested actions:
-  - The error might be represented by slightly different related response code phrases. However, this error in general means malformed SIP message - something is wrong with SIP message received from SBC. Check the SBC configuration to determine why it offers invalid/unsupported SIP message format (e.g. missing FROM header, invalid CSeq header) in request to Microsoft
+  - The error might be represented by slightly different related response code phrases. However, this error in general indicates a malformed SIP message. That is, something is wrong in the SIP message that's received from SBC. Check the SBC configuration to determine why it offers an invalid or unsupported SIP message format (for example, a missing FROM header or an invalid CSeq header) in requests to Microsoft
 
 ## 569002 504 Unable to deliver INVITE: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond
 
@@ -51,7 +51,7 @@ This article provides troubleshooting information for various combinations of th
 - SIP response code: **504**
 - Suggested actions:  
   - Check whether the SBC is functional.
-  - Check whether the SBC is reachable through the specific IP and port. Also, check your firewall settings to make sure that connection to SBC isn't blocked.
+  - Check whether the SBC is reachable through the specified IP and port. Also, check your firewall settings to make sure that connectivity to SBC isn't blocked.
 
 ## 569002 504 Unable to deliver INVITE: No connection could be made because the target machine actively refused it
 
@@ -59,7 +59,7 @@ This article provides troubleshooting information for various combinations of th
 - SIP response code: **504**
 - Suggested actions:  
   - Check whether the SBC is functional.
-  - Check whether the SBC is reachable through the specific IP and port. Also, check your firewall settings to make sure that connection to SBC isn't blocked.
+  - Check whether the SBC is reachable through the specified IP and port. Also, check your firewall settings to make sure that connectivity to SBC isn't blocked.
 
 ## 569002 504 Unable to deliver INVITE: outgoing TLS negotiation failed; HRESULT=0x80096004
 
@@ -67,7 +67,7 @@ This article provides troubleshooting information for various combinations of th
 - SIP response code: **504**
 - Suggested actions:  
   - Check whether the SBC is functional.
-  - Check whether the SBC is reachable through the specific IP and port. Also, check your firewall settings to make sure that connection to SBC isn't blocked.
+  - Check whether the SBC is reachable through the specified IP and port. Also, check your firewall settings to make sure that connectivity to SBC isn't blocked.\
 
 ## 569002 504 Unable to deliver INVITE: outgoing TLS negotiation failed; Wrong target principal name configured. HRESULT=0x80090322 CERT_E_WRONG_USAGE
 
@@ -96,7 +96,7 @@ This article provides troubleshooting information for various combinations of th
 - SIP response code: **504**
 - Suggested actions:  
   - Check whether the SBC is functional.
-  - Check whether the SBC is reachable through the specific IP and port. Also, check your firewall settings to make sure that connection to SBC isn't blocked.
+  - Check whether the SBC is reachable through the specified IP and port. Also, check your firewall settings to make sure that connectivity to SBC isn't blocked.
 
 ## 569003 504 Unable to deliver INVITE: outgoing TLS negotiation failed; HRESULT=0x80090326
 
@@ -112,7 +112,7 @@ This article provides troubleshooting information for various combinations of th
 - Suggested actions:  
   - Renew the SBC certificate.
 
-  **Note:** When you renew the SBC certificate, you must remove the TLS connections that were established from the SBC to Microsoft by using the old certificate, and re-establish them by using the new certificate. Doing this will make sure that certificate expiration warnings aren't triggered in the Microsoft Teams admin center. To remove the old TLS connections, restart the SBC during a timeframe that has low traffic, such as a maintenance window. If you can't restart the SBC, contact the vendor for instructions to force the closure of all old TLS connections.
+  **Note:** When you renew the SBC certificate, you must remove the TLS connections that were established from the SBC to Microsoft by using the old certificate, and re-establish them by using the new certificate. Doing this will make sure that certificate expiration warnings aren't triggered in the Microsoft Teams admin center. To remove the old TLS connections, restart the SBC during a low-traffic period, such as a maintenance window. If you can't restart the SBC, contact the vendor for instructions to force the closure of all old TLS connections.
 
 ## 569009 504 Unable to deliver INVITE: outgoing TLS negotiation failed; HRESULT=0x80090325 SEC_E_UNTRUSTED_ROOT
 
@@ -121,26 +121,25 @@ This article provides troubleshooting information for various combinations of th
 - Suggested actions:  
   - Request a certificate that's signed by one of the public root certification authorities that are listed in [public trusted certificate for the SBC](/microsoftteams/direct-routing-plan#public-trusted-certificate-for-the-sbc).
 
-  If you have multiple TLS profiles, check that you're using a profile that has the correct certificate when you connect to the Direct Routing interface. If you have multiple TLS profiles on the SBC, make sure that you select a profile that's signed by using a certificate that's trusted by Direct Routing.
+  If you have multiple TLS profiles, verify that you're using a profile that has the correct certificate when you connect to the Direct Routing interface. If you have multiple TLS profiles on the SBC, make sure that you select a profile that's signed by using a certificate that's trusted by Direct Routing.
 
 ## 569015 504 Unable to deliver INVITE: No such host is known
 
 - Microsoft response code: **569015**
 - SIP response code: **504**
 - Suggested actions:
-  - DNS issue on SBC side. Check why FQDN of the SBC couldn't be resolved through DNS.
+  - This is a DNS issue on the SBC side. Check why the FQDN of the SBC couldn't be resolved through DNS.
  
 ## 569016 504 Unable to deliver INVITE/ACK: The requested name is valid, but no data of the requested type was found
 
 - Microsoft response code: **569016**
 - SIP response code: **504**
 - Suggested actions:
-  - The error might be represented by slightly different related response code phrases. However, this error code means that DNS record was found, but not of A or AAAA type (most likely only TXT record was returned, which was added for domain verification purpose). Make sure that proper DNS record type is configured.
+  - The error might be represented by slightly different related response code phrases. However, this error code indicates that DNS record was found, but is not an "A" or "AAAA" type. (Most likely, only a text record was returned and added for domain verification.) Make sure that the correct DNS record type is configured.
 
 ## 569018 504 Unable to deliver INVITE: Invalid Request/Response line
 
 - Microsoft response code: **569018**
 - SIP response code: **504**
 - Suggested actions:
-  - The error might be represented by slightly different related response code phrases. However, this error in general means malformed SIP message - something is wrong with SIP message received from SBC. Check the SBC configuration to determine why it offers invalid/unsupported SIP message format (e.g. missing FROM header, extra/wrong character, etc). 
-
+  - The error might be represented by slightly different related response code phrases. However, this error in general indicates a malformed SIP message. That is, something is wrong in the SIP message that was received from SBC. Check the SBC configuration to determine why it offers an invalid or unsupported SIP message format (for example, a missing FROM header, or an extra or incorrect character). 

--- a/Teams/phone-system/direct-routing/microsoft-sip-response-codes-504.md
+++ b/Teams/phone-system/direct-routing/microsoft-sip-response-codes-504.md
@@ -135,7 +135,7 @@ This article provides troubleshooting information for various combinations of th
 - Microsoft response code: **569016**
 - SIP response code: **504**
 - Suggested actions:
-  - The error might be represented by slightly different related response code phrases. However, this error code indicates that DNS record was found, but is not an "A" or "AAAA" type. (Most likely, only a text record was returned and added for domain verification.) Make sure that the correct DNS record type is configured.
+  - The error might be represented by slightly different related response code phrases. However, this error code indicates that a DNS record was found, but it's not an "A" or "AAAA" type. (Most likely, only a text record was returned and added for domain verification.) Make sure that the correct DNS record type is configured.
 
 ## 569018 504 Unable to deliver INVITE: Invalid Request/Response line
 

--- a/Teams/phone-system/direct-routing/microsoft-sip-response-codes-504.md
+++ b/Teams/phone-system/direct-routing/microsoft-sip-response-codes-504.md
@@ -38,6 +38,13 @@ This article provides troubleshooting information for various combinations of th
 - Suggested actions:  
   - Make sure that requests and responses include SIP version "SIP/2.0" in the Request-URI, Via header, and other relevant headers. For more information, see [Direct Routing - SIP protocol](/microsoftteams/direct-routing-protocols-sip).
 
+## 549018 504 Unable to deliver INVITE: Invalid Request/Response line
+
+- Microsoft response code: **549018**
+- SIP response code: **504**
+- Suggested actions:
+  - The error might be represented by slightly different related response code phrases. However, this error in general means malformed SIP message - something is wrong with SIP message received from customer's SBC. Check the SBC configuration to determine why it offers invalid/unsupported SIP message format (e.g. missing FROM header, invalid CSeq header) in request to Microsoft
+
 ## 569002 504 Unable to deliver INVITE: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond
 
 - Microsoft response code: **569002**

--- a/Teams/phone-system/direct-routing/microsoft-sip-response-codes-504.md
+++ b/Teams/phone-system/direct-routing/microsoft-sip-response-codes-504.md
@@ -43,7 +43,7 @@ This article provides troubleshooting information for various combinations of th
 - Microsoft response code: **549018**
 - SIP response code: **504**
 - Suggested actions:
-  - The error might be represented by slightly different related response code phrases. However, this error in general means malformed SIP message - something is wrong with SIP message received from customer's SBC. Check the SBC configuration to determine why it offers invalid/unsupported SIP message format (e.g. missing FROM header, invalid CSeq header) in request to Microsoft
+  - The error might be represented by slightly different related response code phrases. However, this error in general means malformed SIP message - something is wrong with SIP message received from SBC. Check the SBC configuration to determine why it offers invalid/unsupported SIP message format (e.g. missing FROM header, invalid CSeq header) in request to Microsoft
 
 ## 569002 504 Unable to deliver INVITE: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond
 
@@ -122,3 +122,25 @@ This article provides troubleshooting information for various combinations of th
   - Request a certificate that's signed by one of the public root certification authorities that are listed in [public trusted certificate for the SBC](/microsoftteams/direct-routing-plan#public-trusted-certificate-for-the-sbc).
 
   If you have multiple TLS profiles, check that you're using a profile that has the correct certificate when you connect to the Direct Routing interface. If you have multiple TLS profiles on the SBC, make sure that you select a profile that's signed by using a certificate that's trusted by Direct Routing.
+
+## 569015 504 Unable to deliver INVITE: No such host is known
+
+- Microsoft response code: **569015**
+- SIP response code: **504**
+- Suggested actions:
+  - DNS issue on SBC side. Check why FQDN of the SBC couldn't be resolved through DNS.
+ 
+## 569016 504 Unable to deliver INVITE/ACK: The requested name is valid, but no data of the requested type was found
+
+- Microsoft response code: **569016**
+- SIP response code: **504**
+- Suggested actions:
+  - The error might be represented by slightly different related response code phrases. However, this error code means that DNS record was found, but not of A or AAAA type (most likely only TXT record was returned, which was added for domain verification purpose). Make sure that proper DNS record type is configured.
+
+## 569018 504 Unable to deliver INVITE: Invalid Request/Response line
+
+- Microsoft response code: **569018**
+- SIP response code: **504**
+- Suggested actions:
+  - The error might be represented by slightly different related response code phrases. However, this error in general means malformed SIP message - something is wrong with SIP message received from SBC. Check the SBC configuration to determine why it offers invalid/unsupported SIP message format (e.g. missing FROM header, extra/wrong character, etc). 
+


### PR DESCRIPTION
The following combinations of response codes have been added to the existing documentation:

403	510546	"Get Outbound Direct routing - no trunk config found by LBR selection criteria"
488	531052	"Cannot negotiate a new modality with blackhole media"
503	540998	"Service Unavailable - Service state: Inactive/DrainingTransactions"
504	549018	"Unable to deliver INVITE: Invalid Request/Response line"
504	569015	Unable to deliver INVITE: No such host is known"
504	569016	"Unable to deliver INVITE/ACK: The requested name is valid, but no data of the requested type was found"
504	569018	"Unable to deliver INVITE: Invalid Request/Response lin"



