### PR TITLE
Extend doc, to whitelist ms-teams_autostarter.exe and indicate that teams may crash, not just be blocked on start-up

### DIFF
--- a/Teams/teams-administration/include-exclude-teams-from-antivirus-dlp.md
+++ b/Teams/teams-administration/include-exclude-teams-from-antivirus-dlp.md
@@ -1,5 +1,5 @@
 ---
-title: Exclude antivirus and DLP applications from blocking Teams
+title: Prevent Antivirus and DLP Tools from Blocking or Crashing Microsoft Teams
 ms.author: meerak
 author: cloud-writer
 manager: dcscontentpm
@@ -21,9 +21,37 @@ ms.reviewer: davidsle
 description: Provides instructions to add Teams to antivirus and DLP applications so that it can start correctly.
 ---
 
-# Exclude antivirus and DLP applications from blocking Teams
+# Prevent Antivirus and DLP Tools from Blocking or Crashing Microsoft Teams
 
-Third-party antivirus and data loss prevention (DLP) applications can interfere with the Microsoft Teams app and prevent it from starting correctly. When you use non-Microsoft antivirus or DLP applications in PCs, you can include or approve the use of the Teams app on the computers. This action helps to enhance the performance of the PCs and mitigate the effect of the antivirus and DLP applications on security.
+Third-party antivirus, reliability monitoring and data loss prevention (DLP) applications can interfere with the Microsoft Teams app and webview2, leading to unexpected app exits and performance degradations of the Teams client. When you use non-Microsoft antivirus or DLP applications in PCs, you can include or approve the use of the Teams app, Teams updater and [Edge Webview2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/?form=MA13LH) on the computers, to improve application stability and efficency.
+
+## New Teams
+
+To prevent issues with starting or using the new Teams app, *add all the following processes* to the exclusion list in the antivirus software that you’re using:
+
+- `msedgewebview2.exe`
+- `ms-teams.exe`
+- `ms-teamsupdate.exe`
+- `ms-teams_autostarter.exe`
+
+Alternatively, you can add the processes to the allowlist for programs in your DLP application. The method to accomplish this addition varies. For specific instructions, contact your DLP application’s manufacturer.
+
+The MSIX installer installs the new Teams app in the WindowsApps folder instead of the user profile folder, where the classic Teams app is installed. Because users can’t write to the WindowsApps folder, this location adds better protection against attacks that try to alter the installation of the Teams app.
+
+**Note**: The MSIX installer and all files in the same directory are signed with a Microsoft certificate.
+
+The name of the folder where the new Teams app is installed is dynamic and it changes when the app’s version is updated. The folder name begins with MSTeams_, ends with _8wekyb3d8bbwe, and includes the app’s version number in between.  For example, MSTeams_23247.1112.2396.409_x64_8wekyb3d8bbwe.
+
+### Location of the Teams installation folder
+
+To add the Teams processes to either the exclusion list or the Safe list/Allow list, you can find their location by using the following steps:
+
+1. Open Windows PowerShell and type the following cmdlet to determine the location of the installation files:
+   `Get-AppPackage -name "msteams"`
+
+   The output includes the value of the **InstallLocation** parameter such as C:\Program Files\WindowsApps\ MSTeams_23247.1112.2396.409_x64_8wekyb3d8bbwe.
+1. To view the individual files, open **Task Manager** and select **More details**.
+1. On the **Details** tab, locate and right-click **ms-teams.exe** and select **Open file location**.
 
 ## Classic Teams
 
@@ -36,31 +64,5 @@ To prevent issues with starting the classic Teams app, add the following process
 
 Alternatively, you can add the processes to the allowlist for programs in your DLP application. The method to accomplish this addition varies. For specific instructions, contact your DLP application’s manufacturer.
 
-## New Teams
-
-The MSIX installer installs the new Teams app in the WindowsApps folder instead of the user profile folder, where the classic Teams app is installed. Because users can’t write to the WindowsApps folder, this location adds better protection against attacks that try to alter the installation of the Teams app.
-
-**Note**: The MSIX installer and all files in the same directory are signed with a Microsoft certificate.
-
-The name of the folder where the new Teams app is installed is dynamic and it changes when the app’s version is updated. The folder name begins with MSTeams_, ends with _8wekyb3d8bbwe, and includes the app’s version number in between.  For example, MSTeams_23247.1112.2396.409_x64_8wekyb3d8bbwe.
-
-To prevent issues with starting or using the new Teams app, add the following processes to the exclusion list in the antivirus software that you’re using:
-
-- `ms-teams.exe`
-- `ms-teamsupdate.exe`
-- `msedgewebview2.exe`
-
-Alternatively, you can add the processes to the allowlist for programs in your DLP application. The method to accomplish this addition varies. For specific instructions, contact your DLP application’s manufacturer.
-
-### Location of the Teams installation folder
-
-To add the Teams processes to either the exclusion list or the Safe list/Allow list, you can find their location by using the following steps:
-
-1. Open Windows PowerShell and type the following cmdlet to determine the location of the installation files:
-   `Get-AppPackage -name "msteams"`
-
-   The output includes the value of the **InstallLocation** parameter such as C:\Program Files\WindowsApps\ MSTeams_23247.1112.2396.409_x64_8wekyb3d8bbwe.
-1. To view the individual files, open **Task Manager** and select **More details**.
-1. On the **Details** tab, locate and right-click **ms-teams.exe** and select **Open file location**.
 
 Still need help? Go to [Microsoft Support Community](https://answers.microsoft.com).


### PR DESCRIPTION
- [X] Extend doc, to whitelist ms-teams_autostarter.exe
- [X] Specify that teams may crash because of this (and not just be blocked on startup). An  example is webview2 RENDER_PROCESS_EXITED, error code -1073740760, where webview2 crashes due to third party interference antivurs/monitoring tools (leading the teams client app to restart).
- [X] Show first new teams desktop, then classic one (for relevance).


